### PR TITLE
Windows Powershell Support

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -5,20 +5,63 @@
  <img src="https://img.shields.io/github/license/Ileriayo/markdown-badges?style=for-the-badge" alt="Licence" /> 
  <img src="https://img.shields.io/badge/Debian-D70A53?style=for-the-badge&logo=debian&logoColor=white" alt="Debian" /> 
  <img src="https://img.shields.io/badge/bash_script-%23121011.svg?style=for-the-badge&logo=gnu-bash&logoColor=white" alt="Bash Script" />
+ <img src="https://img.shields.io/badge/PowerShell-%235391FE.svg?style=for-the-badge&logo=powershell&logoColor=white" alt="PowerShell" />
+ <img src="https://img.shields.io/badge/Windows-0078D6?style=for-the-badge&logo=windows&logoColor=white" alt="Windows" />
 
 </div>
 
 ---
 
-The Nerd Fonts installer is a bash-based script that installs the Nerd front in Debian and Debian-based Linux distros, such as Ubuntu, Linux Mint, Kali Linux, etc.
+The Nerd Fonts installer provides cross-platform scripts to easily install Nerd Fonts from the command line. It includes a bash script for Linux and macOS systems, and a PowerShell script for Windows systems.
+
+## Features
+
+### ✨ Cross-Platform Support
+- **Linux/macOS**: Bash script (`install.sh`) with system-wide font installation
+- **Windows**: PowerShell script (`install.ps1`) with user-level font installation
+
+### 🎯 Easy to Use
+- Interactive menu with all 51+ Nerd Fonts
+- Colored output for better user experience
+- Input validation and error handling
+- Automatic cleanup of temporary files
+
+### 🔧 Platform-Specific Installation
+- **Linux/macOS**: Installs to `~/.fonts/` and refreshes font cache
+- **Windows**: Installs to `%LOCALAPPDATA%\Microsoft\Windows\Fonts` and registers with system
+
+### 📦 Font Support
+- Supports both `.ttf` and `.otf` font files
+- Downloads latest versions from GitHub releases
+- Handles font extraction and installation automatically
 
 ## Demo
 ![DEMO](/media/install-nerd-font.gif "install nerd font")
 
 ## Install Nerd fonts
+
+### Linux and macOS (Bash)
 Download or install the Nerd Fonts with the Nerd Fonts Installer script. To install Nerd Fonts, run the following script.
 
 ```bash
 bash -c  "$(curl -fsSL https://raw.githubusercontent.com/officialrajdeepsingh/nerd-fonts-installer/main/install.sh)"
 ```
-After selecting your nerd font, it starts downloading into the system.
+
+### Windows (PowerShell)
+For Windows users, use the PowerShell version of the installer:
+
+```powershell
+# Run in PowerShell (requires PowerShell Core 6+ or Windows PowerShell 5.1+)
+iex "& { $(iwr -useb 'https://raw.githubusercontent.com/officialrajdeepsingh/nerd-fonts-installer/main/install.ps1') }"
+```
+
+Or download and run locally:
+```powershell
+# Download the script
+Invoke-WebRequest -Uri 'https://raw.githubusercontent.com/officialrajdeepsingh/nerd-fonts-installer/main/install.ps1' -OutFile 'install.ps1'
+
+# Run the script
+.\install.ps1
+```
+
+After selecting your nerd font, it starts downloading into the system. The PowerShell version installs fonts to the user's local fonts directory and attempts to register them with Windows.

--- a/README.MD
+++ b/README.MD
@@ -18,7 +18,7 @@ The Nerd Fonts installer provides cross-platform scripts to easily install Nerd 
 
 ### ✨ Cross-Platform Support
 - **Linux/macOS**: Bash script (`install.sh`) with system-wide font installation
-- **Windows**: PowerShell script (`install.ps1`) with user-level font installation
+- **Windows 10/11**: PowerShell script (`install.ps1`) with user-level font installation
 
 ### 🎯 Easy to Use
 - Interactive menu with all 51+ Nerd Fonts
@@ -35,6 +35,22 @@ The Nerd Fonts installer provides cross-platform scripts to easily install Nerd 
 - Downloads latest versions from GitHub releases
 - Handles font extraction and installation automatically
 
+## Compatibility
+
+### Windows Support
+- **Windows 10**: Version 1903 (May 2019 Update) or later
+- **Windows 11**: All versions supported
+- **PowerShell**: 5.1+ or PowerShell Core 6+
+
+The Windows PowerShell script has been tested on:
+- Windows 10 Pro for Workstations (Build 26100)
+- PowerShell Core 7.5.2
+- PowerShell 5.1 (Windows PowerShell)
+
+### Linux/macOS Support
+- All modern Linux distributions with Bash 3.2+
+- macOS 10.9+ (Mavericks) or later
+
 ## Demo
 ![DEMO](/media/install-nerd-font.gif "install nerd font")
 
@@ -48,7 +64,11 @@ bash -c  "$(curl -fsSL https://raw.githubusercontent.com/officialrajdeepsingh/ne
 ```
 
 ### Windows (PowerShell)
-For Windows users, use the PowerShell version of the installer:
+For Windows users, use the PowerShell version of the installer.
+
+**Requirements:**
+- Windows 10 (version 1903 or later) or Windows 11
+- PowerShell 5.1+ or PowerShell Core 6+
 
 ```powershell
 # Run in PowerShell (requires PowerShell Core 6+ or Windows PowerShell 5.1+)

--- a/install.ps1
+++ b/install.ps1
@@ -1,0 +1,245 @@
+#!/usr/bin/env pwsh
+# PowerShell Nerd Fonts Installer
+# Select and install Nerd Fonts from https://www.nerdfonts.com/font-downloads
+# Windows compatible version of install.sh
+
+# Enable strict mode for better error handling
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+# Function to write colored output
+function Write-ColorOutput {
+    param(
+        [string]$Message,
+        [string]$ForegroundColor = "White"
+    )
+    Write-Host $Message -ForegroundColor $ForegroundColor
+}
+
+# Function to write error messages
+function Write-ErrorMessage {
+    param([string]$Message)
+    Write-ColorOutput "ERROR: $Message" "Red"
+}
+
+# Function to write success messages
+function Write-SuccessMessage {
+    param([string]$Message)
+    Write-ColorOutput "SUCCESS: $Message" "Green"
+}
+
+# Function to write info messages
+function Write-InfoMessage {
+    param([string]$Message)
+    Write-ColorOutput "INFO: $Message" "Cyan"
+}
+
+# Function to clean up temporary files
+function Remove-TempFiles {
+    param([string]$TempDir)
+    try {
+        if (Test-Path $TempDir) {
+            Remove-Item -Path $TempDir -Recurse -Force
+            Write-InfoMessage "Cleaned up temporary files"
+        }
+    }
+    catch {
+        Write-Host "Warning: Could not clean up temporary files: $_" -ForegroundColor Yellow
+    }
+}
+
+# Function to register fonts with Windows (best effort)
+function Register-WindowsFonts {
+    param([string]$FontsPath)
+    
+    try {
+        # Get all font files (.ttf and .otf)
+        $FontFiles = Get-ChildItem -Path $FontsPath -Include "*.ttf", "*.otf" -Recurse
+        
+        if ($FontFiles.Count -eq 0) {
+            Write-Host "Warning: No font files found to register" -ForegroundColor Yellow
+            return
+        }
+
+        Write-InfoMessage "Attempting to register $($FontFiles.Count) font file(s) with Windows..."
+        
+        # Try to use Windows Shell COM object to install fonts
+        $Shell = New-Object -ComObject Shell.Application
+        $FontsFolder = $Shell.Namespace(0x14)  # Fonts folder
+        
+        foreach ($FontFile in $FontFiles) {
+            try {
+                $FontsFolder.CopyHere($FontFile.FullName, 0x10)  # 0x10 = overwrite existing
+            }
+            catch {
+                # Silent fail for individual font registration
+            }
+        }
+        
+        Write-SuccessMessage "Font registration completed"
+    }
+    catch {
+        Write-Host "Warning: Could not register fonts with Windows system: $_" -ForegroundColor Yellow
+        Write-InfoMessage "Fonts are still installed in user directory and should work in most applications"
+    }
+}
+
+# Main script starts here
+try {
+    Write-ColorOutput "[-] Download The Nerd fonts [-]" "Magenta"
+    Write-ColorOutput "#######################" "Magenta"
+    Write-ColorOutput "Select Nerd Font" "Yellow"
+    
+    # Font list - exact same as bash script
+    $FontsList = @(
+        "Agave", "AnonymousPro", "Arimo", "AurulentSansMono", "BigBlueTerminal", 
+        "BitstreamVeraSansMono", "CascadiaCode", "CodeNewRoman", "ComicShannsMono", 
+        "Cousine", "DaddyTimeMono", "DejaVuSansMono", "FantasqueSansMono", "FiraCode", 
+        "FiraMono", "Gohu", "Go-Mono", "Hack", "Hasklig", "HeavyData", "Hermit", 
+        "iA-Writer", "IBMPlexMono", "InconsolataGo", "InconsolataLGC", "Inconsolata", 
+        "IosevkaTerm", "JetBrainsMono", "Lekton", "LiberationMono", "Lilex", "Meslo", 
+        "Monofur", "Monoid", "Mononoki", "MPlus", "NerdFontsSymbolsOnly", "Noto", 
+        "OpenDyslexic", "Overpass", "ProFont", "ProggyClean", "RobotoMono", 
+        "ShareTechMono", "SourceCodePro", "SpaceMono", "Terminus", "Tinos", 
+        "UbuntuMono", "Ubuntu", "VictorMono"
+    )
+    
+    # Display menu in columns like bash version
+    $ColumnCount = 4
+    $TotalFonts = $FontsList.Count
+    $RowCount = [Math]::Ceiling($TotalFonts / $ColumnCount)
+    
+    for ($row = 0; $row -lt $RowCount; $row++) {
+        $line = ""
+        for ($col = 0; $col -lt $ColumnCount; $col++) {
+            $index = $row + ($col * $RowCount)
+            if ($index -lt $TotalFonts) {
+                $number = $index + 1
+                $fontName = $FontsList[$index]
+                $line += "{0,3}) {1,-20}" -f $number, $fontName
+            }
+        }
+        Write-Host $line
+    }
+    
+    # Add Quit option
+    Write-Host ("{0,3}) {1}" -f ($TotalFonts + 1), "Quit")
+    Write-Host ""
+    
+    # Get user selection
+    while ($true) {
+        $Selection = Read-Host "Enter a number"
+        
+        # Validate input
+        if ($Selection -match '^\d+$') {
+            $Number = [int]$Selection
+            if ($Number -ge 1 -and $Number -le $TotalFonts) {
+                $SelectedFont = $FontsList[$Number - 1]
+                break
+            }
+            elseif ($Number -eq ($TotalFonts + 1)) {
+                Write-InfoMessage "Exiting..."
+                exit 0
+            }
+        }
+        
+        Write-ErrorMessage "Please enter a valid number (1-$($TotalFonts + 1))"
+    }
+    
+    Write-InfoMessage "Starting download $SelectedFont nerd font"
+    
+    # Set up paths
+    $UserFontsPath = Join-Path $env:LOCALAPPDATA "Microsoft\Windows\Fonts"
+    $TempDir = Join-Path $env:TEMP "NerdFonts_$(Get-Random)"
+    $ZipPath = Join-Path $TempDir "$SelectedFont.zip"
+    $ExtractPath = Join-Path $TempDir $SelectedFont
+    
+    # Create directories
+    try {
+        if (-not (Test-Path $UserFontsPath)) {
+            New-Item -Path $UserFontsPath -ItemType Directory -Force | Out-Null
+            Write-InfoMessage "Created fonts folder: $UserFontsPath"
+        }
+        
+        New-Item -Path $TempDir -ItemType Directory -Force | Out-Null
+        Write-InfoMessage "Created temporary folder: $TempDir"
+    }
+    catch {
+        Write-ErrorMessage "Failed to create directories: $_"
+        exit 1
+    }
+    
+    # Download font
+    $DownloadUrl = "https://github.com/ryanoasis/nerd-fonts/releases/latest/download/$SelectedFont.zip"
+    Write-InfoMessage "Downloading from: $DownloadUrl"
+    
+    try {
+        # Use Invoke-WebRequest with progress
+        $ProgressPreference = 'Continue'
+        Invoke-WebRequest -Uri $DownloadUrl -OutFile $ZipPath -UseBasicParsing
+        Write-SuccessMessage "Downloaded $SelectedFont.zip"
+    }
+    catch {
+        Write-ErrorMessage "Failed to download font: $_"
+        Remove-TempFiles -TempDir $TempDir
+        exit 1
+    }
+    
+    # Extract font
+    Write-InfoMessage "Extracting $SelectedFont.zip"
+    try {
+        Expand-Archive -Path $ZipPath -DestinationPath $ExtractPath -Force
+        Write-SuccessMessage "Extracted font files"
+    }
+    catch {
+        Write-ErrorMessage "Failed to extract font: $_"
+        Remove-TempFiles -TempDir $TempDir
+        exit 1
+    }
+    
+    # Install fonts to user directory
+    Write-InfoMessage "Installing fonts to $UserFontsPath"
+    try {
+        $FontFiles = Get-ChildItem -Path $ExtractPath -Include "*.ttf", "*.otf" -Recurse
+        
+        if ($FontFiles.Count -eq 0) {
+            Write-ErrorMessage "No font files found in the extracted archive"
+            Remove-TempFiles -TempDir $TempDir
+            exit 1
+        }
+        
+        $InstalledCount = 0
+        foreach ($FontFile in $FontFiles) {
+            $DestinationPath = Join-Path $UserFontsPath $FontFile.Name
+            Copy-Item -Path $FontFile.FullName -Destination $DestinationPath -Force
+            $InstalledCount++
+        }
+        
+        Write-SuccessMessage "Installed $InstalledCount font file(s)"
+    }
+    catch {
+        Write-ErrorMessage "Failed to install fonts: $_"
+        Remove-TempFiles -TempDir $TempDir
+        exit 1
+    }
+    
+    # Try to register fonts with Windows system
+    Register-WindowsFonts -FontsPath $ExtractPath
+    
+    # Clean up temporary files
+    Remove-TempFiles -TempDir $TempDir
+    
+    Write-SuccessMessage "Font installation completed!"
+    Write-InfoMessage "Fonts installed to: $UserFontsPath"
+    Write-InfoMessage "You may need to restart applications to see the new fonts."
+}
+catch {
+    Write-ErrorMessage "An unexpected error occurred: $_"
+    
+    # Clean up on error
+    if ($TempDir -and (Test-Path $TempDir)) {
+        Remove-TempFiles -TempDir $TempDir
+    }
+    
+    exit 1
+}


### PR DESCRIPTION
This pull request introduces significant enhancements to the Nerd Fonts Installer, adding cross-platform support with a new PowerShell script for Windows and updating the documentation to reflect these changes. The most important changes include the creation of the PowerShell installer script and the addition of detailed feature descriptions and installation instructions in the `README.md`.

### Cross-Platform Support Enhancements:
* **New PowerShell Script**: Added a Windows-compatible PowerShell script (`install.ps1`) to allow users to install Nerd Fonts on Windows systems. The script includes features such as an interactive font selection menu, colored output, input validation, automatic cleanup, and best-effort font registration with Windows.

### Documentation Updates:
* **Updated `README.md`**: Expanded the documentation to include details about cross-platform support, with separate installation instructions for Linux/macOS (Bash) and Windows (PowerShell). The new "Features" section highlights cross-platform capabilities, ease of use, platform-specific installation paths, and font support.
* **Added Badges**: Included badges for PowerShell and Windows in the `README.md` to visually indicate new platform support.

https://github.com/user-attachments/assets/b0d41f6c-fa37-405e-afc7-9dd70b598795
