### PR TITLE
Made a clearer error message on incorrect input

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -45,7 +45,7 @@ select font_name in "${fons_list[@]}" "Quit";
 
     else
         
-        echo "Select the vaild $font_name nerd Font, just type number"
+        echo "Select a valid Nerd Font, just type a number between 1-70."
         continue;
 
     fi


### PR DESCRIPTION
Currently the error message when inputting an incorrect input is: "Select the vaild $font_name nerd Font, just type number"
I made it: "Select a valid Nerd Font, just type a number between 1-70.", which is more idiomatic.